### PR TITLE
NIP-6 - Multi-Account Hierarchy for Deterministic Wallets

### DIFF
--- a/NIPs/nip-0006.md
+++ b/NIPs/nip-0006.md
@@ -20,9 +20,11 @@
     - [Use case #2: Unsecure money receiver](#use-case-2-unsecure-money-receiver)
   - [Resources](#resources)
   - [Compatibility](#compatibility)
+  - [KMAC vs HMAC](#kmac-vs-hmac)
   - [Conclusion](#conclusion)
 - [Specification](#specification)
-  - [Conversion functions](#conversion-functions)
+  - [Hardened Key Derivation](#hardened-key-derivation)
+  - [Derivation with KMAC](#derivation-with-kmac)
   - [Extended keys](#extended-keys)
     - [Key trees](#key-trees)
     - [Compatibility](#compatibility)
@@ -40,7 +42,7 @@
 
 This document describes hierarchical deterministic wallets for NEM.
 
-This document uses Bitcoin's [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki), [BIP43](https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki) and [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) as sources of documentation.
+This document uses Bitcoin's [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki), [BIP43](https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki), [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) and [SLIP-10](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) as sources of documentation.
 
 A standard for deterministic wallets creation is needed to improve handling of NEM wallets within client applications.
 
@@ -56,19 +58,30 @@ Deterministic wallets do not require frequent backups as they will permit the ge
 
 This multi-account hierarchy will support _several chains of keypairs_ (multiple trees) as to allow selective sharing of wallet public keys. 
 
-Additionally, we will be defining Mnemonic code for generating deterministic keys using the definition in [Bitcoin BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki).
+Additionally, we will be defining Mnemonic codes for generating deterministic keys using the definition in [Bitcoin BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki).
 
-Furthermore, using [Bitcoin BIP44], we will define a scheme to build logical hierarchies for deterministic wallets. This will represent the recommended method to work with NEM CATAPULT wallets and keys.
+Furthermore, using [Bitcoin BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki), we will define a scheme to build logical hierarchies for deterministic wallets. This will represent the recommended method to work with NEM CATAPULT wallets and keys.
 
 ### Non-Hardened Child Key Derivation
 
-It has been [discussed](https://github.com/nemtech/NIP/issues/12) that non-hardened child key derivation may not fill any required use-case.
+It has been [decided](https://github.com/nemtech/NIP/issues/12) that non-hardened child key derivation may not fill any required use-case.
+
+As such, the implementation proposal will be providing **only hardened child key derivation**.
+
+At first, the [SLIP-10](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) algorithm was used to implement ED25519 compliant child key derivation. A second proposal implementation includes the possibility to use `KMAC` instead of `HMAC`, this will be described more in details in section [KMAC vs HMAC](#kmac-vs-hmac).
 
 #### Use case \#1: Facilitate Audit Process
 
 The non-hardened child key derivation model can be used to facilitate the process of auditing a hierarchical deterministic wallet. By sharing the non-hardened extended public key at the top of the tree in a HD wallet, one can give an auditor the ability to view all addresses in the wallet *without the ability to generate the associated private keys*.
 
 Reference: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#audits-nm
+
+**Relevance Issue**: 
+
+Discussion from https://github.com/nemtech/NIP/issues/12#issuecomment-484525238
+
+> Any auditor will simply request ALL your public keys.
+> ownership of public keys can be easily shown (by signing some predefined message), but even without this, I fail to see a reason, where you would like to give to auditor MORE public keys than you actually own...
 
 #### Use case \#2: Unsecure money receiver
 
@@ -80,7 +93,7 @@ Reference: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#unsecu
 
 ### Resources:
 
-Following are the proposed implementation for BIP32-ED25519 extended keys. The implementation proposal by the Cardano team was defined in a paper that can be found in the resources as well:
+Following are the proposed implementations for BIP32-ED25519 extended keys. The implementation proposal by the Cardano team was defined in a paper that can be found in the resources as well:
 
 - *DOC1*: [BIP32-Ed25519 Hierarchical Deterministic Keys over a Non-linear Keyspace](https://cardanolaunch.com/assets/Ed25519_BIP.pdf)
 - *IMPL1*: [Cardano Implementation Proposal in RUST](https://github.com/input-output-hk/rust-cardano/commit/5dd1416249128d7346028ef8cce713fd7bda0f28#diff-20f5bbac575dbd279d57a5959a3eb883)
@@ -89,7 +102,7 @@ Following are the proposed implementation for BIP32-ED25519 extended keys. The i
 
 ### Compatibility
 
-Following table describes compatibility of implementation proposal with regards to *hardened* key derivation and *non-hardened* key derivaton.
+Following table describes compatibility of implementation proposal with regards to *hardened* child key derivation and *non-hardened* child key derivaton.
 
 | Resource | Language | Hardened CKD | Non-Hardened CKD |
 | --- | --- | --- | --- |
@@ -97,25 +110,50 @@ Following table describes compatibility of implementation proposal with regards 
 | *IMPL2* | JS/TS | **YES** | **NO** |
 | *IMPL3* | rust | **YES** | **NO** |
 
+### KMAC vs HMAC
+
+In order to improve the key derivation algorithm, we may be using `KMAC256k(m)` in places where SLIP-10 and BIP-32 use `HMAC(k||m)`. This is because _KMAC_ presents better compatibility with SHA-3 and avoids the danger of colliding uses. 
+
+Additionally, the `KMAC` approach should be simpler and faster than the `HMAC` approach because it does not require _an additional pass of the hash algorithm_.
+
+The `KMAC` wording stands for `Keccak Message Authentication Code`, it is an alternative to the `HMAC` algorithm which stands for `Hash-Based Message Authentication Code`.
+
+More details about KMAC can be found in following NIST publication: 
+
+    https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf
+
 ### Conclusion
 
 The described use cases make it potentially *useful* to implement non-hardened child key derivation scheme.
 
 Due to the complexity of implementation and **status** of the available *resources* for the *ed25519-compatible non-hardended child key derivation* implementation, it may be decided to *drop support of non-hardened child key derivation* as we are aiming for **stable**, **tested** and **maintained** solutions for this NIP to be a success in cross-client interoperability.
 
+**Resolution**: **Hardened child key derivation** will be the only available scheme of derivation for Catapult hierarchical deterministic wallets.
+
 ## Specification
 
 Following section defines the technical specification of the proposed `Multi-Account Hierarchy for Deterministic Wallets`.
 
-### Conversion functions
+### Hardened Key Derivation
 
-From the Bitcoin standard, as **standard conversion functions**, we assume:
+In our implementation proposal, we will be defining methods to derive master and child keys for **hardened paths** only. This means that any key that is derived using the subsequent library will be a **hardened key**.
 
-- `point(p)`: returns the coordinate pair resulting from EC point multiplication (repeated application of the EC group operation) of the **ED25519** base point with the integer p.
-- `ser32(i)`: serialize a 32-bit unsigned integer `i` as a 4-byte sequence, most significant byte first.
-- `ser256(p)`: serializes the integer `p` as a 32-byte sequence, most significant byte first.
-- `serP(P)`: serializes the coordinate pair `P = (x,y)` as a byte sequence using [SEC1](https://www.secg.org/sec1-v2.pdf)'s compressed form: (0x02 or 0x03) || ser256(x), where the header byte depends on the parity of the omitted y coordinate.
-- `parse256(p)`: interprets a 32-byte sequence as a 256-bit number, most significant byte first.
+In the **BIP32** and **BIP44** proposals, hardened keys are to be defined by having an **apostrophe** (') as the suffix of the path level index. Examples of _hardened paths_ include :
+
+- `m/44'/43'/0'/0'/0'`: first account, internal keychain, first address.
+- `m/44'/43'/0'/0'/1'`: first account, internal keychain, second address.
+- `m/44'/43'/1'/0'/5'`: second account, internal keychain, sixth address.
+- `m/44'/43'/1'/1'/5'`: second account, external keychain, sixth address.
+
+:warning: **Following this definition, paths will _automatically_ be hardened in case they are non-hardened.**
+
+### KMAC Derivation
+
+In our implementation proposal, we will _permit the use of `KMAC`_. Any key derived for the Catapult engine/network, will be using `KMAC`, whilst keys derived for the `Bitcoin` or Bitcoin-alike protocol/network will be using `HMAC` as to provide compatibility with other hierarchical deterministic keys derivation implementations.
+
+As such, we will provide with a `MACType` enumeration and `MACImpl` class implementation that permits to switch between `KMAC` and `HMAC`.
+
+:warning: **It is not recommened to generate/derive keys for Catapult with the `HMAC` approach as this will produce keys that are not compatible with the chosen `KMAC` approach.**
 
 ### Extended keys
 
@@ -131,6 +169,44 @@ Multiple *child key derivation* functions (CKDs) are proposed in [BIP32](https:/
 - ~~[**Public** parent key --> **Public** child key: `CKDpub((Kpar, cpar), i) → (Ki, ci)`](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#public-parent-key--public-child-key)~~ [EDIT: It is proposed to drop this CKD function]
 - [**Private** parent key --> **Public** child key: `N((k, c)) → (K, c)`](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#private-parent-key--public-child-key)
 - It is not possible to derive a **private** child key from a **public** parent key.
+
+#### Catapult updates
+
+With regards to the BIP32 standard definition, Catapult extended keys will be different in several aspects including:
+
+- Keys are derived using the `ed25519` elliptic curve instead of the `secp256k` curve.
+- Keys are derived using the `KMAC` codes instead of `HMAC` codes.
+- Extended Keys have 2<sup>31</sub> **hardened child keys** as it is not possible to derive _non-hardened child keys_ with our implementation.
+
+To this extent, our implementation proposal implements the following child key derivation methods:
+
+#### Private parent key --> Private child key: `CKDpriv((kpar, cpar), i) → (ki, ci)`
+
+The function CKDpriv((k<sub>par</sub>, c<sub>par</sub>), i) → (k<sub>i</sub>, c<sub>i</sub>) computes a child extended _private_ key from the parent extended _private_ key with steps defined below.
+
+This implementation proposal makes use of the [SLIP-10](https://github.com/satoshilabs/slips/blob/master/slip-0010.md#private-parent-key--private-child-key) proposed `CKDPriv` implementation **with the difference that KMAC is used instead of HMAC**.
+
+1. Take hardened child: `let I = KMAC256(Key = c<sub>par</sub>, Data = 0x00 || set<sub>p</sub>(point(k<sub>par)) || ser<sub>32</sub>(i))
+2. Split `I` into two _32-byte sequences_, I<sub>L</sub> and I<sub>R</sub>
+3. The returned **chain code** c<sub>i</sub> is **I<sub>R</sub>**.
+4. The returned **child key** k<sub>i</sub> is **I<sub>L</sub>**.
+
+The KMAC256 function is specified in [NIST.SP800-185](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf).
+
+#### Public parent key --> Public child key
+
+This function is not available in our implementation proposal.
+
+#### Private parent key --> Public child key: `N((k, c)) → (K, c)`
+
+The function `N((k, c)) → (K, c)` computes the extended public key corresponding to an extended private key. This will compute the the **neutered** version and removes the ability to sign transactions.
+
+- The returned key K is point(k).
+- The returned chain code c is just the passed chain code.
+
+To compute the public child key of a parent private key:
+
+- N(CKDpriv((k<sub>par</sub>, c<sub>par</sub>), i))
 
 #### Key trees
 
@@ -152,8 +228,9 @@ From the Bitcoin BIP32 description:
 
 > Private and public keys must be kept safe as usual. Leaking a private key means access to coins - leaking a public key can mean loss of privacy.
 
-> Somewhat more care must be taken regarding extended keys, as these correspond to an entire (sub)tree of keys.
+:warning: **Important Security Implication**
 
+> Somewhat more care must be taken regarding extended keys, as these correspond to an entire (sub)tree of keys.
 > One weakness that may not be immediately obvious, is that knowledge of a parent extended public key plus any non-hardened private key descending from it is equivalent to knowing the parent extended private key (and thus every private and public key descending from it). This means that extended public keys must be treated more carefully than regular public keys. It is also the reason for the existence of hardened keys, and why they are used for the account level in the tree. This way, a leak of account-specific (or below) private key never risks compromising the master or other accounts.
 
 ### Wallet structure
@@ -189,9 +266,7 @@ Because we want to comply to the BIP44 standard we will define path levels as re
 m / purpose' / coin_type' / account' / change' / address_index'
 ```
 
-:warning Note the addition of *hardened* change and address_index path levels. Because Catapult makes use of *ed25519* elliptic curve cryptography, deriving non-hardened extended keys is complicated to implement, while for the derivation of hardened extended keys there is already available implementation proposals.
-
-:warning It is currently being examined whether *non-hardened derivation* is needed at all or not.
+:warning: Note the addition of *hardened* change and address_index path levels. Because Catapult makes use of *ed25519* elliptic curve cryptography, deriving non-hardened extended keys is non-trivial and resources available on this topic are limited. For our implementation, we decided to use **hardened derivation only** because of the simplicity of implementation and the availability of tested resources and publications.
 
 - Our `purpose` level will be `44'` as we are building a logical hierarchy following the BIP44 standard. 
 - Our `coin_type` is `43'` as this corresponds to `NEM` in [SLIP-44 annexed to the source document](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).
@@ -201,7 +276,7 @@ m / purpose' / coin_type' / account' / change' / address_index'
 
 The appended apostrophe (`'`) in path levels is used to mark **hardened key levels**. As defined in Bitcoin BIP32 and in this document's [Wallet structure](#specification-wallet-structure), the BIP32 algorithm permits derivation of two entirely independent keyspaces. Those are usually called **the hardened key space** and **the non-hardened key space**.
 
-The proposed implementation for Catapult/NEM may be limited to **hardened key levels** in order to avoid complexity in the implementation for the first implementation proposal.
+:warning: Our implementation proposal **only permits derivation of one of these keyspaces**, namely **the hardened key space**.
 
 For NEM, we can define a _base logical hierarchy_ of `m/44'/43'`. It is recommended for client implementations to follow this standard in order to achieve better cross-client compatibility.
 
@@ -230,21 +305,28 @@ Following table displays example derivation paths with their corresponding hiera
 
 An implementation proposal has been started with following specification:
 
-- Package name `nem2-hd-wallets` at https://github.com/evias/nem2-hd-wallets
+- Package name `nem2-hd-wallets@0.4.0` at https://github.com/evias/nem2-hd-wallets
 - [`DeterministicKey`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Compat/DeterministicKey.ts) class to provide with `bitcoinjs/bip32` compatibility.
 - [`NodeEd25519`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Curves/NodeEd25519.ts) class to describe hierarchical deterministic nodes for ED25519 elliptic curve cryptography.
+- [`CKDPriv`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Curves/NodeEd25519.ts#L57) function implementation to permit **Private parent key --> Private child key** derivation.
 - [`ExtendedKey`](https://github.com/evias/nem2-hd-wallets/blob/master/src/ExtendedKey.ts) class to add an abstraction layer for actual *keys*, higher level layer for working with extended keys.
 - [`MnemonicPassPhrase`](https://github.com/evias/nem2-hd-wallets/blob/master/src/MnemonicPassPhrase.ts) class to describe BIP39 mnemonic pass phrases.
 - [`Wallet`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Wallet.ts) class to describe hierarchical deterministic wallets compatible with `nem2-sdk` classes `Account` and `PublicAccount`.
+- [`MACType`](https://github.com/evias/nem2-hd-wallets/blob/master/src/MACType.ts) enumeration with `HMAC` and `KMAC`.
+- [`MACImpl`](https://github.com/evias/nem2-hd-wallets/blob/master/src/MACImpl.ts) class with `create` method to accept `MACType.KMAC` or `MACType.HMAC`and create message authentication code accordingly.
+- [`HMAC`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Cryptography.ts#L60) method implementation in `Cryptography` class.
+- [`KMAC`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Cryptography.ts#L76) method implementation in `Cryptography` class.
 
 The current implementation is open for suggestions. The library is now BIP32-compatible and allows generating *hardened-only* ED25519 extended keys.
 
 ### Ongoing Work
 
-- Replace HMAC for KMAC with https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf
-- ~~Implement Wallet interface~~
-- Integrate QR Code interface using `nem2-qr-code` when available.
-- Make sure `privateKey`s can not be leaked through, for example, bad memory management in early draft phase.
+- [x] Replace HMAC for KMAC with https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf
+- [x] Implement Wallet interface
+- [ ] Implement KMAC specialized unit tests
+- [ ] Define relevance of `base58` encoding of extended keys for Catapult.
+- [ ] Integrate QR Code interface using `nem2-qr-code` when available.
+- [ ] Make sure `privateKey`s can not be leaked through, for example, bad memory management in early draft phase.
 
 ## Integration
 
@@ -277,6 +359,7 @@ const defaultAccount = wallet.getChildAccount(`m/44'/43'/0'/0'/0'`);
 - [SLIP-10 compliant ED25519-hd-keys](https://github.com/alepop/ed25519-hd-key/tree/master/src)
 - [SLIP-10 compliant ED25519-hd-keys in RUST](https://github.com/tarassh/ed25519_hd_key/blob/master/src/lib.rs)
 - [BIP32-Ed25519 Hierarchical Deterministic Keys over a Non-linear Keyspace](https://cardanolaunch.com/assets/Ed25519_BIP.pdf)
+- [NIST.SP800-185](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf)
 
 ## History
 
@@ -286,3 +369,4 @@ const defaultAccount = wallet.getChildAccount(`m/44'/43'/0'/0'/0'`);
 | Apr 18 2019   | Second Draft |
 | Apr 23 2019   | Third Draft |
 | Apr 29 2019   | Fourth Draft |
+| May 13 2019   | Fifth Draft |

--- a/NIPs/nip-0006.md
+++ b/NIPs/nip-0006.md
@@ -323,8 +323,10 @@ The current implementation is open for suggestions. The library is now BIP32-com
 
 - [x] Replace HMAC for KMAC with https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf
 - [x] Implement Wallet interface
+- [ ] Implement Wallet creation out of extended private key hexadecimal format
 - [ ] Implement KMAC specialized unit tests
-- [ ] Define relevance of `base58` encoding of extended keys for Catapult.
+- [ ] Add network type and network id in binary extended keys
+- [x] Define relevance of `base58` encoding of extended keys for Catapult. [NOT RELEVANT]
 - [ ] Integrate QR Code interface using `nem2-qr-code` when available.
 - [ ] Make sure `privateKey`s can not be leaked through, for example, bad memory management in early draft phase.
 

--- a/NIPs/nip-hd-wallets.md
+++ b/NIPs/nip-hd-wallets.md
@@ -8,21 +8,32 @@
     Status: Draft
     Type: Standards Track
     Created: 2019-04-09
-    License: MIT
+    License: BSD-2 Clause
 ```
 
 ## Table of contents
 
 - [Abstract](#abstract)
 - [Motivation](#motivation)
-- [Specification: Conversion functions](#specification-conversion-functions)
-- [Specification: Extended keys](#specification-extended-keys)
-  - [Key trees](#key-trees)
+  - [Non-Hardened Child Key Derivation](#non-hardened-child-key-derivation)
+    - [Use case #1: Facilitate Audit Process](#use-case-1-facilitate-audit-process)
+    - [Use case #2: Unsecure money receiver](#use-case-2-unsecure-money-receiver)
+  - [Resources](#resources)
   - [Compatibility](#compatibility)
-  - [Security implications](#security-implications)
-- [Specification: Wallet structure](#specification-wallet-structure)
-- [Specification: Mnemonic seeds](#specification-mnemonic-seeds)
-- [Specification: A logical hierarchy with BIP44](#specification-a-logical-hierarchy-with-bip44)
+  - [Conclusion](#conclusion)
+- [Specification](#specification)
+  - [Conversion functions](#conversion-functions)
+  - [Extended keys](#extended-keys)
+    - [Key trees](#key-trees)
+    - [Compatibility](#compatibility)
+    - [Security implications](#security-implications)
+  - [Wallet structure](#wallet-structure)
+  - [Mnemonic seeds](#mnemonic-seeds)
+  - [A logical hierarchy with BIP44](#a-logical-hierarchy-with-bip44)
+    - [Examples](#examples)
+- [Implementation](#implementation)
+- [References](#references)
+- [History](#history)
 
 ## Abstract
 
@@ -48,7 +59,54 @@ Additionally, we will be defining Mnemonic code for generating deterministic key
 
 Furthermore, using [Bitcoin BIP44], we will define a scheme to build logical hierarchies for deterministic wallets. This will represent the recommended method to work with NEM CATAPULT wallets and keys.
 
-## Specification: Conversion functions
+### Non-Hardened Child Key Derivation
+
+It has been [discussed](https://github.com/nemtech/NIP/issues/12) that non-hardened child key derivation may not fill any required use-case.
+
+#### Use case #1: Facilitate Audit Process
+
+The non-hardened child key derivation model can be used to facilitate the process of auditing a hierarchical deterministic wallet. By sharing the non-hardened extended public key at the top of the tree in a HD wallet, one can give an auditor the ability to view all addresses in the wallet *without the ability to generate the associated private keys*.
+
+Reference: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#audits-nm
+
+#### Use case #2: Unsecure money receiver
+
+The non-hardened child key derivation model can be used when *using unsecure VPS* or *webservers* to run e-commerce websites. In those scenarios, the e-commerce will be configured to derive public keys (addresses) from a non-hardened extended public key as this will make sure that, even if the webserver is ever compromised, there is no chance of losing funds associated with the public keys.
+
+In cases of compromised *money receivers*, there will however be a loss in privacy as the *extended public key* allows for the derivation of a whole tree of child keys making it possible for the attacker to associate public keys to the parent key.
+
+Reference: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#unsecure-money-receiver-nmih0
+
+### Resources:
+
+Following are the proposed implementation for BIP32-ED25519 extended keys. The implementation proposal by the Cardano team was defined in a paper that can be found in the resources as well:
+
+- *DOC1*: [BIP32-Ed25519 Hierarchical Deterministic Keys over a Non-linear Keyspace](https://cardanolaunch.com/assets/Ed25519_BIP.pdf)
+- *IMPL1*: [Cardano Implementation Proposal in RUST](https://github.com/input-output-hk/rust-cardano/commit/5dd1416249128d7346028ef8cce713fd7bda0f28#diff-20f5bbac575dbd279d57a5959a3eb883)
+- *IMPL2*: [SLIP-10 compliant ED25519-hd-keys](https://github.com/alepop/ed25519-hd-key/tree/master/src)
+- *IMPL3*: [SLIP-10 compliant ED25519-hd-keys in RUST](https://github.com/tarassh/ed25519_hd_key/blob/master/src/lib.rs)
+
+### Compatibility
+
+Following table describes compatibility of implementation proposal with regards to *hardened* key derivation and *non-hardened* key derivaton.
+
+| Resource | Language | Hardened CKD | Non-Hardened CKD |
+| --- | --- | --- | --- |
+| *IMPL1* | rust | <span style="color: green;">**YES**</span> | <span style="color: green;">**YES**</span> |
+| *IMPL2* | JS/TS | <span style="color: red;">**NO**</span> | <span style="color: green;">**YES**</span> |
+| *IMPL3* | rust | <span style="color: red;">**NO**</span> | <span style="color: green;">**YES**</span> |
+
+### Conclusion
+
+The described use cases make it potentially *useful* to implement non-hardened child key derivation scheme.
+
+Due to the complexity of implementation and **status** of the available *resources* for the *ed25519-compatible non-hardended child key derivation* implementation, it may be decided to *drop support of non-hardened child key derivation* as we are aiming for **stable**, **tested** and **maintained** solutions for this NIP to be a success in cross-client interoperability.
+
+## Specification
+
+Following section defines the technical specification of the proposed `Multi-Account Hierarchy for Deterministic Wallets`.
+
+### Conversion functions
 
 From the Bitcoin standard, as **standard conversion functions**, we assume:
 
@@ -58,7 +116,7 @@ From the Bitcoin standard, as **standard conversion functions**, we assume:
 - `serP(P)`: serializes the coordinate pair `P = (x,y)` as a byte sequence using [SEC1](https://www.secg.org/sec1-v2.pdf)'s compressed form: (0x02 or 0x03) || ser256(x), where the header byte depends on the parity of the omitted y coordinate.
 - `parse256(p)`: interprets a 32-byte sequence as a 256-bit number, most significant byte first.
 
-## Specification: Extended keys
+### Extended keys
 
 The [Bitcoin BIP32 document](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) describes extended keys in detail. With the following extracts:
 
@@ -69,23 +127,23 @@ The [Bitcoin BIP32 document](https://github.com/bitcoin/bips/blob/master/bip-003
 Multiple *child key derivation* functions (CKDs) are proposed in [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) as well, with the following references :
 
 - [**Private** parent key --> **Private** child key: `CKDpriv((kpar, cpar), i) → (ki, ci)`](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#private-parent-key--private-child-key)
-- [**Public** parent key --> **Public** child key: `CKDpub((Kpar, cpar), i) → (Ki, ci)`](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#public-parent-key--public-child-key)
+- ~~[**Public** parent key --> **Public** child key: `CKDpub((Kpar, cpar), i) → (Ki, ci)`](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#public-parent-key--public-child-key)~~ [EDIT: It is proposed to drop this CKD function]
 - [**Private** parent key --> **Public** child key: `N((k, c)) → (K, c)`](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#private-parent-key--public-child-key)
 - It is not possible to derive a **private** child key from a **public** parent key.
 
-### Key trees
+#### Key trees
 
 In the [source document](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), a key tree is defined that will make use of the CKDs defined above. The child key derivation functions are cascaded several times to build a tree of keys.
 
 Leaf nodes of that tree each define one key (private or public). A detailed explanation of the created key tree can be found [here](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#the-key-tree).
 
-### Compatibility
+#### Compatibility
 
 From the Bitcoin BIP32 standard document: 
 
 > To comply with this standard, a client must at least be able to import an extended public or private key, to give access to its direct descendants as wallet keys. The wallet structure (master/account/chain/subchain) presented in the second part of the specification is advisory only, but is suggested as a minimal structure for easy compatibility - even when no separate accounts or distinction between internal and external chains is made. However, implementations may deviate from it for specific needs; more complex applications may call for a more complex tree structure.
 
-### Security implications
+#### Security implications
 
 Security properties of the Extended Keys proposals can be found [here](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#security).
 
@@ -97,7 +155,7 @@ From the Bitcoin BIP32 description:
 
 > One weakness that may not be immediately obvious, is that knowledge of a parent extended public key plus any non-hardened private key descending from it is equivalent to knowing the parent extended private key (and thus every private and public key descending from it). This means that extended public keys must be treated more carefully than regular public keys. It is also the reason for the existence of hardened keys, and why they are used for the account level in the tree. This way, a leak of account-specific (or below) private key never risks compromising the master or other accounts.
 
-## Specification: Wallet structure
+### Wallet structure
 
 The previous sections specified key trees and their nodes as defined by the Bitcoin BIP32 source document. Next we are imposing a wallet structure that leverages this tree of keys. 
 
@@ -111,7 +169,7 @@ From the Bitcoin BIP32 standard - [The default wallet layout](https://github.com
 
 We will detail the logical hierarchy more in detail in the section [BIP44: A logical hierarchy for deterministic wallets](#specification-bip44-a-logical-hierarchy-for-deterministic-wallets).
 
-## Specification: Mnemonic seeds
+### Mnemonic seeds
 
 Mnemonic seeds are sentences with words matching a [Wordlists](https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md) as well as holding a checksum as defined in [BIP39's `Generating the mnemonic`](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#generating-the-mnemonic).
 
@@ -122,62 +180,96 @@ Following references will be used during reference implementation:
 - [Generating the mnemonic](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#generating-the-mnemonic)
 - [From mnemonic to seed](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#from-mnemonic-to-seed)
 
-## Specification: A logical hierarchy with BIP44
+### A logical hierarchy with BIP44
 
 Because we want to comply to the BIP44 standard we will define path levels as recommended in BIP44. This gives us the following path levels: 
 
 ```
-m / purpose' / coin_type' / account' / change / address_index
+m / purpose' / coin_type' / account' / change' / address_index'
 ```
+
+:warning Note the addition of *hardened* change and address_index path levels. Because Catapult makes use of *ed25519* elliptic curve cryptography, deriving non-hardened extended keys is complicated to implement, while for the derivation of hardened extended keys there is already available implementation proposals.
+
+:warning It is currently being examined whether *non-hardened derivation* is needed at all or not.
 
 - Our `purpose` level will be `44'` as we are building a logical hierarchy following the BIP44 standard. 
 - Our `coin_type` is `43'` as this corresponds to `NEM` in [SLIP-44 annexed to the source document](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).
 - The next level corresponds to the _index_ of the `account` that we want to use, starting at `0` for the **first** account.
-- The `change` path level is used to _define which keychain must be used_. Set to `0`, the keychain used is said to be `external`, while any other `change` path level will result in using the `internal` keychain.
-- The `address_index` path level corresponds to the _index_ of the `address` that we want to use, starting at `0` for the **first** address.
+- The `change` path level is used to _define which keychain must be used_. Set to `0'`, the keychain used is said to be `external`, while any other `change` path level will result in using the `internal` keychain.
+- The `address_index` path level corresponds to the _index_ of the `address` that we want to use, starting at `0'` for the **first** address.
 
-The appended apostrophe (`'`) in path levels is used to mark **hardened key levels**. As defined in Bitcoin BIP32 and in this document's [Wallet structure](#specification-wallet-structure), the BIP32 algorithm permits derivation of two entirely independent keyspaces. Those are usually called **the hardened key space** and **the non-hardened key space**. 
+The appended apostrophe (`'`) in path levels is used to mark **hardened key levels**. As defined in Bitcoin BIP32 and in this document's [Wallet structure](#specification-wallet-structure), the BIP32 algorithm permits derivation of two entirely independent keyspaces. Those are usually called **the hardened key space** and **the non-hardened key space**.
+
+The proposed implementation for Catapult/NEM may be limited to **hardened key levels** in order to avoid complexity in the implementation for the first implementation proposal.
 
 For NEM, we can define a _base logical hierarchy_ of `m/44'/43'`. It is recommended for client implementations to follow this standard in order to achieve better cross-client compatibility.
 
-For client implementations which _do not wish_ to implement the full capabilities of multi-account hierarchy for deterministic wallets, it is **recommended** to use only the following _default address path_: `m/44'/43'/0'/0/0`.
+For client implementations which _do not wish_ to implement the full capabilities of multi-account hierarchy for deterministic wallets, it is **recommended** to use only the following _default address path_: `m/44'/43'/0'/0'/0'`.
 
-### Examples
+#### Examples
+
+Following table displays example derivation paths with their corresponding hierarchy details. The two first path levels, namely the *purpose* and the *coin_type*, are always expected to contain `44'` and `43'` respectively. The next path levels, the third, represents the account number to be derived, and so on.
 
 | account | keychain | address | path |
 |---|---|---|---|
-| **first** | **external** | **first** | `m/44'/43'/0'/0/0` |
-| **first** | **external** | **second** | `m/44'/43'/0'/0/1` |
-| **first** | **external** | **third** | `m/44'/43'/0'/0/2` |
-| **first** | **internal** | **first** | `m/44'/43'/0'/1/0` |
-| **first** | **internal** | **second** | `m/44'/43'/0'/1/1` |
-| **first** | **internal** | **third** | `m/44'/43'/0'/1/2` |
-| **second** | **external** | **first** | `m/44'/43'/1'/0/0` |
-| **second** | **external** | **second** | `m/44'/43'/1'/0/1` |
-| **second** | **external** | **third** | `m/44'/43'/1'/0/2` |
-| **second** | **internal** | **first** | `m/44'/43'/1'/1/0` |
-| **second** | **internal** | **second** | `m/44'/43'/1'/1/1` |
-| **second** | **internal** | **third** | `m/44'/43'/1'/1/2` |
+| **first** | **external** | **first** | `m/44'/43'/0'/0'/0'` |
+| **first** | **external** | **second** | `m/44'/43'/0'/0'/1'` |
+| **first** | **external** | **third** | `m/44'/43'/0'/0'/2'` |
+| **first** | **internal** | **first** | `m/44'/43'/0'/1'/0'` |
+| **first** | **internal** | **second** | `m/44'/43'/0'/1'/1'` |
+| **first** | **internal** | **third** | `m/44'/43'/0'/1'/2'` |
+| **second** | **external** | **first** | `m/44'/43'/1'/0'/0'` |
+| **second** | **external** | **second** | `m/44'/43'/1'/0'/1'` |
+| **second** | **external** | **third** | `m/44'/43'/1'/0'/2'` |
+| **second** | **internal** | **first** | `m/44'/43'/1'/1'/0'` |
+| **second** | **internal** | **second** | `m/44'/43'/1'/1'/1'` |
+| **second** | **internal** | **third** | `m/44'/43'/1'/1'/2'` |
+
+## Implementation
+
+An implementation proposal has been started with following specification:
+
+- Package name `nem2-hd-wallets` at https://github.com/evias/nem2-hd-wallets
+- [`MnemonicPassPhrase`](https://github.com/evias/nem2-hd-wallets/blob/master/src/MnemonicPassPhrase.ts) class to describe BIP39 mnemonic pass phrases.
+- [`ExtendedKeyNode`](https://github.com/evias/nem2-hd-wallets/blob/master/src/ExtendedKeyNode.ts) class to be compatible with BIP32 and NIP? on-demand.
+- [`ExtendedKey`](https://github.com/evias/nem2-hd-wallets/blob/master/src/ExtendedKey.ts) class to add an abstraction layer for actual *keys*, higher level layer for working with extended keys.
+
+The current implementation is open for suggestions. The library is now BIP32-compatible but does not allow generating *ed25519* extended keys yet.
+
+:warning Current working branch [`bip32-ed25519`](https://github.com/evias/nem2-hd-wallets/tree/bip32-ed25519) is not yet compatible with ed25519 extended keys.
+
+## Integration
+
+This package should aim at following integration examples:
+
+```typescript
+import {MnemonicPassPhrase, ExtendedKey} from 'nem2-hd-wallets';
+
+const mnemonic = MnemonicPassPhrase.createRandom();
+const extended = ExtendedKey.fromSeed(mnemonic.toEntropy());
+
+// derive XPRV and XPUB extended keys
+const xprvKey  = extended.getChildPrivateKey(`m/44'/43'/0'/0'/0'`);
+const xpubKey  = extended.getChildPublicKey(`m/44'/43'/0'/0'/0'`);
+```
 
 ## References
 
-- [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
-- [BIP32 - Extended Keys](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#extended-keys)
-- [BIP32 - Child Key Derivation Functions](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#child-key-derivation-ckd-functions)
-- [BIP32 - The key tree](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#the-key-tree)
-- [BIP32 - Master key generation](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#master-key-generation) 
-- [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
-- [BIP39 - Generating the mnemonic](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#generating-the-mnemonic)
-- [BIP39 - Rules about wordlist](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#wordlist)
-- [BIP39 - From mnemonic to seed](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#from-mnemonic-to-seed)
-- [BIP39 - Wordlists](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#wordlists)
-- [BIP43](https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki) 
-- [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
-- [BIP44 - Path levels](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#path-levels)
+- [BIP32: Hierarchical Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
+- [BIP39: Mnemonic code for generating deterministic keys](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
+- [BIP43: Purpose Field for Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki) 
+- [BIP44: Multi-Account Hierarchy for Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
 - [SLIP44 - Registered coin types](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
+- [SLIP10 - Universal private key derivation](https://github.com/satoshilabs/slips/blob/master/slip-0010.md)
+- [evias/nem2-hd-wallets](https://github.com/evias/nem2-hd-wallets)
+- [Cardano Implementation Proposal in RUST](https://github.com/input-output-hk/rust-cardano/commit/5dd1416249128d7346028ef8cce713fd7bda0f28#diff-20f5bbac575dbd279d57a5959a3eb883)
+- [SLIP-10 compliant ED25519-hd-keys](https://github.com/alepop/ed25519-hd-key/tree/master/src)
+- [SLIP-10 compliant ED25519-hd-keys in RUST](https://github.com/tarassh/ed25519_hd_key/blob/master/src/lib.rs)
+- [BIP32-Ed25519 Hierarchical Deterministic Keys over a Non-linear Keyspace](https://cardanolaunch.com/assets/Ed25519_BIP.pdf)
 
 ## History
 
 | **Date**      | **Version**   |
 | ------------- | ------------- |
 | Apr 6 2019    | Initial Draft |
+| Apr 18 2019   | Second Draft |

--- a/NIPs/nip-hd-wallets.md
+++ b/NIPs/nip-hd-wallets.md
@@ -1,0 +1,183 @@
+# NIP-? - Multi-Account Hierarchy for Deterministic Wallets
+
+```
+    NIP: ?
+    Layer: Applications
+    Title: Multi-Account Hierarchy for Deterministic Wallets
+    Author: Grégory Saive <greg@nem.foundation>
+    Status: Draft
+    Type: Standards Track
+    Created: 2019-04-09
+    License: MIT
+```
+
+## Table of contents
+
+- [Abstract](#abstract)
+- [Motivation](#motivation)
+- [Specification: Conversion functions](#specification-conversion-functions)
+- [Specification: Extended keys](#specification-extended-keys)
+  - [Key trees](#key-trees)
+  - [Compatibility](#compatibility)
+  - [Security implications](#security-implications)
+- [Specification: Wallet structure](#specification-wallet-structure)
+- [Specification: Mnemonic seeds](#specification-mnemonic-seeds)
+- [Specification: A logical hierarchy with BIP44](#specification-a-logical-hierarchy-with-bip44)
+
+## Abstract
+
+This document describes hierarchical deterministic wallets for NEM.
+
+This document uses Bitcoin's [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki), [BIP43](https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki) and [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) as sources of documentation.
+
+A standard for deterministic wallets creation is needed to improve handling of NEM wallets within client applications.
+
+This standard will set the rules for generating _extended keys_ as defined in [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), for generating _mnemonic pass phrases_ as defined in [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) and for _defining a logical hierarchy for deterministic wallets_.
+
+Extracts from the Bitcoin documents will be added in quotes and detailed _extensions_  or _updates_ will be annotated for the NEM platform.
+
+## Motivation
+
+Previous versions of NEM clients (wallets) used a _user password_ to encrypt private keys, resulting in the need of creating backups every time when a new private key is generated.
+
+Deterministic wallets do not require frequent backups as they will permit the generation of multiple public keys (addresses) without revealing the _spending private key_, with the use of elliptic curve mathematics.
+
+This multi-account hierarchy will support _several chains of keypairs_ (multiple trees) as to allow selective sharing of wallet public keys. 
+
+Additionally, we will be defining Mnemonic code for generating deterministic keys using the definition in [Bitcoin BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki).
+
+Furthermore, using [Bitcoin BIP44], we will define a scheme to build logical hierarchies for deterministic wallets. This will represent the recommended method to work with NEM CATAPULT wallets and keys.
+
+## Specification: Conversion functions
+
+From the Bitcoin standard, as **standard conversion functions**, we assume:
+
+- `point(p)`: returns the coordinate pair resulting from EC point multiplication (repeated application of the EC group operation) of the **ED25519** base point with the integer p.
+- `ser32(i)`: serialize a 32-bit unsigned integer `i` as a 4-byte sequence, most significant byte first.
+- `ser256(p)`: serializes the integer `p` as a 32-byte sequence, most significant byte first.
+- `serP(P)`: serializes the coordinate pair `P = (x,y)` as a byte sequence using [SEC1](https://www.secg.org/sec1-v2.pdf)'s compressed form: (0x02 or 0x03) || ser256(x), where the header byte depends on the parity of the omitted y coordinate.
+- `parse256(p)`: interprets a 32-byte sequence as a 256-bit number, most significant byte first.
+
+## Specification: Extended keys
+
+The [Bitcoin BIP32 document](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) describes extended keys in detail. With the following extracts:
+
+> We represent an extended private key as (k, c), with k the normal private key, and c the chain code. An extended public key is represented as (K, c), with K = point(k) and c the chain code.
+
+> Each extended key has 2^31 normal child keys, and 2^31 hardened child keys. Each of these child keys has an index. The normal child keys use indices 0 through 2^31-1. The hardened child keys use indices 2^31 through 2^32-1. To ease notation for hardened key indices, a number iH represents i+2^31.
+
+Multiple *child key derivation* functions (CKDs) are proposed in [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) as well, with the following references :
+
+- [**Private** parent key --> **Private** child key: `CKDpriv((kpar, cpar), i) → (ki, ci)`](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#private-parent-key--private-child-key)
+- [**Public** parent key --> **Public** child key: `CKDpub((Kpar, cpar), i) → (Ki, ci)`](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#public-parent-key--public-child-key)
+- [**Private** parent key --> **Public** child key: `N((k, c)) → (K, c)`](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#private-parent-key--public-child-key)
+- It is not possible to derive a **private** child key from a **public** parent key.
+
+### Key trees
+
+In the [source document](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), a key tree is defined that will make use of the CKDs defined above. The child key derivation functions are cascaded several times to build a tree of keys.
+
+Leaf nodes of that tree each define one key (private or public). A detailed explanation of the created key tree can be found [here](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#the-key-tree).
+
+### Compatibility
+
+From the Bitcoin BIP32 standard document: 
+
+> To comply with this standard, a client must at least be able to import an extended public or private key, to give access to its direct descendants as wallet keys. The wallet structure (master/account/chain/subchain) presented in the second part of the specification is advisory only, but is suggested as a minimal structure for easy compatibility - even when no separate accounts or distinction between internal and external chains is made. However, implementations may deviate from it for specific needs; more complex applications may call for a more complex tree structure.
+
+### Security implications
+
+Security properties of the Extended Keys proposals can be found [here](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#security).
+
+From the Bitcoin BIP32 description: 
+
+> Private and public keys must be kept safe as usual. Leaking a private key means access to coins - leaking a public key can mean loss of privacy.
+
+> Somewhat more care must be taken regarding extended keys, as these correspond to an entire (sub)tree of keys.
+
+> One weakness that may not be immediately obvious, is that knowledge of a parent extended public key plus any non-hardened private key descending from it is equivalent to knowing the parent extended private key (and thus every private and public key descending from it). This means that extended public keys must be treated more carefully than regular public keys. It is also the reason for the existence of hardened keys, and why they are used for the account level in the tree. This way, a leak of account-specific (or below) private key never risks compromising the master or other accounts.
+
+## Specification: Wallet structure
+
+The previous sections specified key trees and their nodes as defined by the Bitcoin BIP32 source document. Next we are imposing a wallet structure that leverages this tree of keys. 
+
+From the Bitcoin BIP32 standard - [The default wallet layout](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#the-default-wallet-layout):
+
+> The layout defined in this section is a default only, though clients are encouraged to mimic it for compatibility, even if not all features are supported.
+
+> An hyper deterministic wallet is organized as several `accounts`. Accounts are numbered, the default account ("") being number 0. Clients are not required to support more than one account - if not, they only use the default account.
+
+> Each account is composed of two keypair chains: an **internal** and an **external** one. The _external_ keychain is used to _generate new public addresses_, while the _internal_ keychain is used for _all other operations_.
+
+We will detail the logical hierarchy more in detail in the section [BIP44: A logical hierarchy for deterministic wallets](#specification-bip44-a-logical-hierarchy-for-deterministic-wallets).
+
+## Specification: Mnemonic seeds
+
+Mnemonic seeds are sentences with words matching a [Wordlists](https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md) as well as holding a checksum as defined in [BIP39's `Generating the mnemonic`](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#generating-the-mnemonic).
+
+Mnemonic seeds are created from the available [Wordlists](https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md) in the BIP39 annex.
+
+Following references will be used during reference implementation: 
+
+- [Generating the mnemonic](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#generating-the-mnemonic)
+- [From mnemonic to seed](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#from-mnemonic-to-seed)
+
+## Specification: A logical hierarchy with BIP44
+
+Because we want to comply to the BIP44 standard we will define path levels as recommended in BIP44. This gives us the following path levels: 
+
+```
+m / purpose' / coin_type' / account' / change / address_index
+```
+
+- Our `purpose` level will be `44'` as we are building a logical hierarchy following the BIP44 standard. 
+- Our `coin_type` is `43'` as this corresponds to `NEM` in [SLIP-44 annexed to the source document](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).
+- The next level corresponds to the _index_ of the `account` that we want to use, starting at `0` for the **first** account.
+- The `change` path level is used to _define which keychain must be used_. Set to `0`, the keychain used is said to be `external`, while any other `change` path level will result in using the `internal` keychain.
+- The `address_index` path level corresponds to the _index_ of the `address` that we want to use, starting at `0` for the **first** address.
+
+The appended apostrophe (`'`) in path levels is used to mark **hardened key levels**. As defined in Bitcoin BIP32 and in this document's [Wallet structure](#specification-wallet-structure), the BIP32 algorithm permits derivation of two entirely independent keyspaces. Those are usually called **the hardened key space** and **the non-hardened key space**. 
+
+For NEM, we can define a _base logical hierarchy_ of `m/44'/43'`. It is recommended for client implementations to follow this standard in order to achieve better cross-client compatibility.
+
+For client implementations which _do not wish_ to implement the full capabilities of multi-account hierarchy for deterministic wallets, it is **recommended** to use only the following _default address path_: `m/44'/43'/0'/0/0`.
+
+### Examples
+
+| account | keychain | address | path |
+|---|---|---|---|
+| **first** | **external** | **first** | `m/44'/43'/0'/0/0` |
+| **first** | **external** | **second** | `m/44'/43'/0'/0/1` |
+| **first** | **external** | **third** | `m/44'/43'/0'/0/2` |
+| **first** | **internal** | **first** | `m/44'/43'/0'/1/0` |
+| **first** | **internal** | **second** | `m/44'/43'/0'/1/1` |
+| **first** | **internal** | **third** | `m/44'/43'/0'/1/2` |
+| **second** | **external** | **first** | `m/44'/43'/1'/0/0` |
+| **second** | **external** | **second** | `m/44'/43'/1'/0/1` |
+| **second** | **external** | **third** | `m/44'/43'/1'/0/2` |
+| **second** | **internal** | **first** | `m/44'/43'/1'/1/0` |
+| **second** | **internal** | **second** | `m/44'/43'/1'/1/1` |
+| **second** | **internal** | **third** | `m/44'/43'/1'/1/2` |
+
+## References
+
+- [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
+- [BIP32 - Extended Keys](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#extended-keys)
+- [BIP32 - Child Key Derivation Functions](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#child-key-derivation-ckd-functions)
+- [BIP32 - The key tree](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#the-key-tree)
+- [BIP32 - Master key generation](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#master-key-generation) 
+- [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
+- [BIP39 - Generating the mnemonic](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#generating-the-mnemonic)
+- [BIP39 - Rules about wordlist](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#wordlist)
+- [BIP39 - From mnemonic to seed](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#from-mnemonic-to-seed)
+- [BIP39 - Wordlists](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#wordlists)
+- [BIP43](https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki) 
+- [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
+- [BIP44 - Path levels](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#path-levels)
+- [SLIP44 - Registered coin types](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
+
+## History
+
+| **Date**      | **Version**   |
+| ------------- | ------------- |
+| Apr 6 2019    | Initial Draft |

--- a/NIPs/nip-hd-wallets.md
+++ b/NIPs/nip-hd-wallets.md
@@ -32,6 +32,7 @@
   - [A logical hierarchy with BIP44](#a-logical-hierarchy-with-bip44)
     - [Examples](#examples)
 - [Implementation](#implementation)
+  - [Ongoing Work](#ongoing-work)
 - [References](#references)
 - [History](#history)
 
@@ -63,13 +64,13 @@ Furthermore, using [Bitcoin BIP44], we will define a scheme to build logical hie
 
 It has been [discussed](https://github.com/nemtech/NIP/issues/12) that non-hardened child key derivation may not fill any required use-case.
 
-#### Use case #1: Facilitate Audit Process
+#### Use case \#1: Facilitate Audit Process
 
 The non-hardened child key derivation model can be used to facilitate the process of auditing a hierarchical deterministic wallet. By sharing the non-hardened extended public key at the top of the tree in a HD wallet, one can give an auditor the ability to view all addresses in the wallet *without the ability to generate the associated private keys*.
 
 Reference: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#audits-nm
 
-#### Use case #2: Unsecure money receiver
+#### Use case \#2: Unsecure money receiver
 
 The non-hardened child key derivation model can be used when *using unsecure VPS* or *webservers* to run e-commerce websites. In those scenarios, the e-commerce will be configured to derive public keys (addresses) from a non-hardened extended public key as this will make sure that, even if the webserver is ever compromised, there is no chance of losing funds associated with the public keys.
 
@@ -92,9 +93,9 @@ Following table describes compatibility of implementation proposal with regards 
 
 | Resource | Language | Hardened CKD | Non-Hardened CKD |
 | --- | --- | --- | --- |
-| *IMPL1* | rust | <span style="color: green;">**YES**</span> | <span style="color: green;">**YES**</span> |
-| *IMPL2* | JS/TS | <span style="color: red;">**NO**</span> | <span style="color: green;">**YES**</span> |
-| *IMPL3* | rust | <span style="color: red;">**NO**</span> | <span style="color: green;">**YES**</span> |
+| *IMPL1* | rust | **YES** | **YES** |
+| *IMPL2* | JS/TS | **YES** | **NO** |
+| *IMPL3* | rust | **YES** | **NO** |
 
 ### Conclusion
 
@@ -234,9 +235,14 @@ An implementation proposal has been started with following specification:
 - [`ExtendedKeyNode`](https://github.com/evias/nem2-hd-wallets/blob/master/src/ExtendedKeyNode.ts) class to be compatible with BIP32 and NIP? on-demand.
 - [`ExtendedKey`](https://github.com/evias/nem2-hd-wallets/blob/master/src/ExtendedKey.ts) class to add an abstraction layer for actual *keys*, higher level layer for working with extended keys.
 
-The current implementation is open for suggestions. The library is now BIP32-compatible but does not allow generating *ed25519* extended keys yet.
+The current implementation is open for suggestions. The library is now BIP32-compatible and allows generating *hardened-only* ED25519 extended keys.
 
-:warning Current working branch [`bip32-ed25519`](https://github.com/evias/nem2-hd-wallets/tree/bip32-ed25519) is not yet compatible with ed25519 extended keys.
+### Ongoing Work
+
+- Replace HMAC for KMAC with https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf
+- Implement Wallet interface
+- Integrate QR Code interface using `nem2-qr-code` when available.
+- Make sure `privateKey`s can not be leaked through, for example, bad memory management in early draft phase.
 
 ## Integration
 

--- a/NIPs/nip-hd-wallets.md
+++ b/NIPs/nip-hd-wallets.md
@@ -1,7 +1,7 @@
-# NIP-? - Multi-Account Hierarchy for Deterministic Wallets
+# NIP-6 - Multi-Account Hierarchy for Deterministic Wallets
 
 ```
-    NIP: ?
+    NIP: 6
     Layer: Applications
     Title: Multi-Account Hierarchy for Deterministic Wallets
     Author: Grégory Saive <greg@nem.foundation>
@@ -164,7 +164,7 @@ From the Bitcoin BIP32 standard - [The default wallet layout](https://github.com
 
 > The layout defined in this section is a default only, though clients are encouraged to mimic it for compatibility, even if not all features are supported.
 
-> An hyper deterministic wallet is organized as several `accounts`. Accounts are numbered, the default account ("") being number 0. Clients are not required to support more than one account - if not, they only use the default account.
+> An ~~hyper~~hierarchical deterministic wallet is organized as several `accounts`. Accounts are numbered, the default account ("") being number 0. Clients are not required to support more than one account - if not, they only use the default account.
 
 > Each account is composed of two keypair chains: an **internal** and an **external** one. The _external_ keychain is used to _generate new public addresses_, while the _internal_ keychain is used for _all other operations_.
 
@@ -231,16 +231,18 @@ Following table displays example derivation paths with their corresponding hiera
 An implementation proposal has been started with following specification:
 
 - Package name `nem2-hd-wallets` at https://github.com/evias/nem2-hd-wallets
-- [`MnemonicPassPhrase`](https://github.com/evias/nem2-hd-wallets/blob/master/src/MnemonicPassPhrase.ts) class to describe BIP39 mnemonic pass phrases.
-- [`ExtendedKeyNode`](https://github.com/evias/nem2-hd-wallets/blob/master/src/ExtendedKeyNode.ts) class to be compatible with BIP32 and NIP? on-demand.
+- [`DeterministicKey`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Compat/DeterministicKey.ts) class to provide with `bitcoinjs/bip32` compatibility.
+- [`NodeEd25519`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Curves/NodeEd25519.ts) class to describe hierarchical deterministic nodes for ED25519 elliptic curve cryptography.
 - [`ExtendedKey`](https://github.com/evias/nem2-hd-wallets/blob/master/src/ExtendedKey.ts) class to add an abstraction layer for actual *keys*, higher level layer for working with extended keys.
+- [`MnemonicPassPhrase`](https://github.com/evias/nem2-hd-wallets/blob/master/src/MnemonicPassPhrase.ts) class to describe BIP39 mnemonic pass phrases.
+- [`Wallet`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Wallet.ts) class to describe hierarchical deterministic wallets compatible with `nem2-sdk` classes `Account` and `PublicAccount`.
 
 The current implementation is open for suggestions. The library is now BIP32-compatible and allows generating *hardened-only* ED25519 extended keys.
 
 ### Ongoing Work
 
 - Replace HMAC for KMAC with https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf
-- Implement Wallet interface
+- ~~Implement Wallet interface~~
 - Integrate QR Code interface using `nem2-qr-code` when available.
 - Make sure `privateKey`s can not be leaked through, for example, bad memory management in early draft phase.
 
@@ -249,14 +251,17 @@ The current implementation is open for suggestions. The library is now BIP32-com
 This package should aim at following integration examples:
 
 ```typescript
-import {MnemonicPassPhrase, ExtendedKey} from 'nem2-hd-wallets';
+import {MnemonicPassPhrase, ExtendedKey, Wallet} from 'nem2-hd-wallets';
 
 const mnemonic = MnemonicPassPhrase.createRandom();
 const extended = ExtendedKey.fromSeed(mnemonic.toEntropy());
+const wallet = new Wallet(extended);
 
-// derive XPRV and XPUB extended keys
-const xprvKey  = extended.getChildPrivateKey(`m/44'/43'/0'/0'/0'`);
-const xpubKey  = extended.getChildPublicKey(`m/44'/43'/0'/0'/0'`);
+// derive *master* account (not recommended)
+const masterAccount = wallet.getAccount();
+
+// derive *default* account (recommended)
+const defaultAccount = wallet.getChildAccount(`m/44'/43'/0'/0'/0'`);
 ```
 
 ## References
@@ -279,3 +284,5 @@ const xpubKey  = extended.getChildPublicKey(`m/44'/43'/0'/0'/0'`);
 | ------------- | ------------- |
 | Apr 6 2019    | Initial Draft |
 | Apr 18 2019   | Second Draft |
+| Apr 23 2019   | Third Draft |
+| Apr 29 2019   | Fourth Draft |


### PR DESCRIPTION
# NIP-6 - Multi-Account Hierarchy for Deterministic Wallets

```
    NIP: 6
    Layer: Application
    Title: Multi-Account Hierarchy for Deterministic Wallets
    Author: Grégory Saive <greg@nem.foundation>
    Discussions-To: #sig-client
    Comments-URI: https://github.com/nemtech/NIP/issues/12
    Status: Draft
    Type: Standards Track
    Created: 2019-04-09
    License: BSD-2 Clause
```

## Abstract

This document describes hierarchical deterministic wallets for NEM.

This document uses Bitcoin's [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki), [BIP43](https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki), [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) and [SLIP-10](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) as sources of documentation.

A standard for deterministic wallets creation is needed to improve handling of NEM wallets within client applications.

This standard will set the rules for generating _extended keys_ as defined in [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), for generating _mnemonic pass phrases_ as defined in [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) and for _defining a logical hierarchy for deterministic wallets_.

Extracts from the Bitcoin documents will be added in quotes and detailed _extensions_  or _updates_ will be annotated for the NEM platform.

## Motivation

Previous versions of NEM clients (wallets) used a _user password_ to encrypt private keys, resulting in the need of creating backups every time when a new private key is generated.

Deterministic wallets do not require frequent backups as they will permit the generation of multiple public keys (addresses) without revealing the _spending private key_, with the use of elliptic curve mathematics.

This multi-account hierarchy will support _several chains of keypairs_ (multiple trees) as to allow selective sharing of wallet public keys. 

Additionally, we will be defining Mnemonic codes for generating deterministic keys using the definition in [Bitcoin BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki).

Furthermore, using [Bitcoin BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki), we will define a scheme to build logical hierarchies for deterministic wallets. This will represent the recommended method to work with NEM CATAPULT wallets and keys.

### Non-Hardened Child Key Derivation

It has been [decided](https://github.com/nemtech/NIP/issues/12) that non-hardened child key derivation may not fill any required use-case.

As such, the implementation proposal will be providing **only hardened child key derivation**.

At first, the [SLIP-10](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) algorithm was used to implement ED25519 compliant child key derivation. A second proposal implementation includes the possibility to use `KMAC` instead of `HMAC`, this will be described more in details in section [KMAC vs HMAC](#kmac-vs-hmac).

#### Use case \#1: Facilitate Audit Process

The non-hardened child key derivation model can be used to facilitate the process of auditing a hierarchical deterministic wallet. By sharing the non-hardened extended public key at the top of the tree in a HD wallet, one can give an auditor the ability to view all addresses in the wallet *without the ability to generate the associated private keys*.

Reference: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#audits-nm

**Relevance Issue**: 

Discussion from https://github.com/nemtech/NIP/issues/12#issuecomment-484525238

> Any auditor will simply request ALL your public keys.
> ownership of public keys can be easily shown (by signing some predefined message), but even without this, I fail to see a reason, where you would like to give to auditor MORE public keys than you actually own...

#### Use case \#2: Unsecure money receiver

The non-hardened child key derivation model can be used when *using unsecure VPS* or *webservers* to run e-commerce websites. In those scenarios, the e-commerce will be configured to derive public keys (addresses) from a non-hardened extended public key as this will make sure that, even if the webserver is ever compromised, there is no chance of losing funds associated with the public keys.

In cases of compromised *money receivers*, there will however be a loss in privacy as the *extended public key* allows for the derivation of a whole tree of child keys making it possible for the attacker to associate public keys to the parent key.

Reference: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#unsecure-money-receiver-nmih0

### Resources:

Following are the proposed implementations for BIP32-ED25519 extended keys. The implementation proposal by the Cardano team was defined in a paper that can be found in the resources as well:

- *DOC1*: [BIP32-Ed25519 Hierarchical Deterministic Keys over a Non-linear Keyspace](https://cardanolaunch.com/assets/Ed25519_BIP.pdf)
- *IMPL1*: [Cardano Implementation Proposal in RUST](https://github.com/input-output-hk/rust-cardano/commit/5dd1416249128d7346028ef8cce713fd7bda0f28#diff-20f5bbac575dbd279d57a5959a3eb883)
- *IMPL2*: [SLIP-10 compliant ED25519-hd-keys](https://github.com/alepop/ed25519-hd-key/tree/master/src)
- *IMPL3*: [SLIP-10 compliant ED25519-hd-keys in RUST](https://github.com/tarassh/ed25519_hd_key/blob/master/src/lib.rs)

### Compatibility

Following table describes compatibility of implementation proposal with regards to *hardened* child key derivation and *non-hardened* child key derivaton.

| Resource | Language | Hardened CKD | Non-Hardened CKD |
| --- | --- | --- | --- |
| *IMPL1* | rust | **YES** | **YES** |
| *IMPL2* | JS/TS | **YES** | **NO** |
| *IMPL3* | rust | **YES** | **NO** |

### KMAC vs HMAC

In order to improve the key derivation algorithm, we may be using `KMAC256k(m)` in places where SLIP-10 and BIP-32 use `HMAC(k||m)`. This is because _KMAC_ presents better compatibility with SHA-3 and avoids the danger of colliding uses. 

Additionally, the `KMAC` approach should be simpler and faster than the `HMAC` approach because it does not require _an additional pass of the hash algorithm_.

The `KMAC` wording stands for `Keccak Message Authentication Code`, it is an alternative to the `HMAC` algorithm which stands for `Hash-Based Message Authentication Code`.

More details about KMAC can be found in following NIST publication: 

    https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf

### Conclusion

The described use cases make it potentially *useful* to implement non-hardened child key derivation scheme.

Due to the complexity of implementation and **status** of the available *resources* for the *ed25519-compatible non-hardended child key derivation* implementation, it may be decided to *drop support of non-hardened child key derivation* as we are aiming for **stable**, **tested** and **maintained** solutions for this NIP to be a success in cross-client interoperability.

**Resolution**: **Hardened child key derivation** will be the only available scheme of derivation for Catapult hierarchical deterministic wallets.

## Specification

Following section defines the technical specification of the proposed `Multi-Account Hierarchy for Deterministic Wallets`.

### Hardened Key Derivation

In our implementation proposal, we will be defining methods to derive master and child keys for **hardened paths** only. This means that any key that is derived using the subsequent library will be a **hardened key**.

In the **BIP32** and **BIP44** proposals, hardened keys are to be defined by having an **apostrophe** (') as the suffix of the path level index. Examples of _hardened paths_ include :

- `m/44'/43'/0'/0'/0'`: first account, internal keychain, first address.
- `m/44'/43'/0'/0'/1'`: first account, internal keychain, second address.
- `m/44'/43'/1'/0'/5'`: second account, internal keychain, sixth address.
- `m/44'/43'/1'/1'/5'`: second account, external keychain, sixth address.

:warning: **Following this definition, paths will _automatically_ be hardened in case they are non-hardened.**

### KMAC Derivation

In our implementation proposal, we will _permit the use of `KMAC`_. Any key derived for the Catapult engine/network, will be using `KMAC`, whilst keys derived for the `Bitcoin` or Bitcoin-alike protocol/network will be using `HMAC` as to provide compatibility with other hierarchical deterministic keys derivation implementations.

As such, we will provide with a `MACType` enumeration and `MACImpl` class implementation that permits to switch between `KMAC` and `HMAC`.

:warning: **It is not recommened to generate/derive keys for Catapult with the `HMAC` approach as this will produce keys that are not compatible with the chosen `KMAC` approach.**

### Extended keys

The [Bitcoin BIP32 document](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) describes extended keys in detail. With the following extracts:

> We represent an extended private key as (k, c), with k the normal private key, and c the chain code. An extended public key is represented as (K, c), with K = point(k) and c the chain code.

> Each extended key has 2^31 normal child keys, and 2^31 hardened child keys. Each of these child keys has an index. The normal child keys use indices 0 through 2^31-1. The hardened child keys use indices 2^31 through 2^32-1. To ease notation for hardened key indices, a number iH represents i+2^31.

Multiple *child key derivation* functions (CKDs) are proposed in [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) as well, with the following references :

- [**Private** parent key --> **Private** child key: `CKDpriv((kpar, cpar), i) → (ki, ci)`](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#private-parent-key--private-child-key)
- ~~[**Public** parent key --> **Public** child key: `CKDpub((Kpar, cpar), i) → (Ki, ci)`](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#public-parent-key--public-child-key)~~ [EDIT: It is proposed to drop this CKD function]
- [**Private** parent key --> **Public** child key: `N((k, c)) → (K, c)`](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#private-parent-key--public-child-key)
- It is not possible to derive a **private** child key from a **public** parent key.

#### Catapult updates

With regards to the BIP32 standard definition, Catapult extended keys will be different in several aspects including:

- Keys are derived using the `ed25519` elliptic curve instead of the `secp256k` curve.
- Keys are derived using the `KMAC` codes instead of `HMAC` codes.
- Extended Keys have 2<sup>31</sub> **hardened child keys** as it is not possible to derive _non-hardened child keys_ with our implementation.

To this extent, our implementation proposal implements the following child key derivation methods:

#### Private parent key --> Private child key: `CKDpriv((kpar, cpar), i) → (ki, ci)`

The function CKDpriv((k<sub>par</sub>, c<sub>par</sub>), i) → (k<sub>i</sub>, c<sub>i</sub>) computes a child extended _private_ key from the parent extended _private_ key with steps defined below.

This implementation proposal makes use of the [SLIP-10](https://github.com/satoshilabs/slips/blob/master/slip-0010.md#private-parent-key--private-child-key) proposed `CKDPriv` implementation **with the difference that KMAC is used instead of HMAC**.

1. Take hardened child: `let I = KMAC256(Key = c<sub>par</sub>, Data = 0x00 || set<sub>p</sub>(point(k<sub>par)) || ser<sub>32</sub>(i))
2. Split `I` into two _32-byte sequences_, I<sub>L</sub> and I<sub>R</sub>
3. The returned **chain code** c<sub>i</sub> is **I<sub>R</sub>**.
4. The returned **child key** k<sub>i</sub> is **I<sub>L</sub>**.

The KMAC256 function is specified in [NIST.SP800-185](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf).

#### Public parent key --> Public child key

This function is not available in our implementation proposal.

#### Private parent key --> Public child key: `N((k, c)) → (K, c)`

The function `N((k, c)) → (K, c)` computes the extended public key corresponding to an extended private key. This will compute the the **neutered** version and removes the ability to sign transactions.

- The returned key K is point(k).
- The returned chain code c is just the passed chain code.

To compute the public child key of a parent private key:

- N(CKDpriv((k<sub>par</sub>, c<sub>par</sub>), i))

#### Key trees

In the [source document](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), a key tree is defined that will make use of the CKDs defined above. The child key derivation functions are cascaded several times to build a tree of keys.

Leaf nodes of that tree each define one key (private or public). A detailed explanation of the created key tree can be found [here](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#the-key-tree).

#### Compatibility

From the Bitcoin BIP32 standard document: 

> To comply with this standard, a client must at least be able to import an extended public or private key, to give access to its direct descendants as wallet keys. The wallet structure (master/account/chain/subchain) presented in the second part of the specification is advisory only, but is suggested as a minimal structure for easy compatibility - even when no separate accounts or distinction between internal and external chains is made. However, implementations may deviate from it for specific needs; more complex applications may call for a more complex tree structure.

#### Security implications

Security properties of the Extended Keys proposals can be found [here](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#security).

From the Bitcoin BIP32 description: 

> Private and public keys must be kept safe as usual. Leaking a private key means access to coins - leaking a public key can mean loss of privacy.

:warning: **Important Security Implication**

> Somewhat more care must be taken regarding extended keys, as these correspond to an entire (sub)tree of keys.
> One weakness that may not be immediately obvious, is that knowledge of a parent extended public key plus any non-hardened private key descending from it is equivalent to knowing the parent extended private key (and thus every private and public key descending from it). This means that extended public keys must be treated more carefully than regular public keys. It is also the reason for the existence of hardened keys, and why they are used for the account level in the tree. This way, a leak of account-specific (or below) private key never risks compromising the master or other accounts.

### Wallet structure

The previous sections specified key trees and their nodes as defined by the Bitcoin BIP32 source document. Next we are imposing a wallet structure that leverages this tree of keys. 

From the Bitcoin BIP32 standard - [The default wallet layout](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#the-default-wallet-layout):

> The layout defined in this section is a default only, though clients are encouraged to mimic it for compatibility, even if not all features are supported.

> An ~~hyper~~hierarchical deterministic wallet is organized as several `accounts`. Accounts are numbered, the default account ("") being number 0. Clients are not required to support more than one account - if not, they only use the default account.

> Each account is composed of two keypair chains: an **internal** and an **external** one. The _external_ keychain is used to _generate new public addresses_, while the _internal_ keychain is used for _all other operations_.

We will detail the logical hierarchy more in detail in the section [BIP44: A logical hierarchy for deterministic wallets](#specification-bip44-a-logical-hierarchy-for-deterministic-wallets).

### Mnemonic seeds

Mnemonic seeds are sentences with words matching a [Wordlists](https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md) as well as holding a checksum as defined in [BIP39's `Generating the mnemonic`](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#generating-the-mnemonic).

Mnemonic seeds are created from the available [Wordlists](https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md) in the BIP39 annex.

Following references will be used during reference implementation: 

- [Generating the mnemonic](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#generating-the-mnemonic)
- [From mnemonic to seed](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#from-mnemonic-to-seed)

### A logical hierarchy with BIP44

Because we want to comply to the BIP44 standard we will define path levels as recommended in BIP44. This gives us the following path levels: 

```
m / purpose' / coin_type' / account' / change' / address_index'
```

:warning: Note the addition of *hardened* change and address_index path levels. Because Catapult makes use of *ed25519* elliptic curve cryptography, deriving non-hardened extended keys is non-trivial and resources available on this topic are limited. For our implementation, we decided to use **hardened derivation only** because of the simplicity of implementation and the availability of tested resources and publications.

- Our `purpose` level will be `44'` as we are building a logical hierarchy following the BIP44 standard. 
- Our `coin_type` is `43'` as this corresponds to `NEM` in [SLIP-44 annexed to the source document](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).
- The next level corresponds to the _index_ of the `account` that we want to use, starting at `0` for the **first** account.
- The `change` path level is used to _define which keychain must be used_. Set to `0'`, the keychain used is said to be `external`, while any other `change` path level will result in using the `internal` keychain.
- The `address_index` path level corresponds to the _index_ of the `address` that we want to use, starting at `0'` for the **first** address.

The appended apostrophe (`'`) in path levels is used to mark **hardened key levels**. As defined in Bitcoin BIP32 and in this document's [Wallet structure](#specification-wallet-structure), the BIP32 algorithm permits derivation of two entirely independent keyspaces. Those are usually called **the hardened key space** and **the non-hardened key space**.

:warning: Our implementation proposal **only permits derivation of one of these keyspaces**, namely **the hardened key space**.

For NEM, we can define a _base logical hierarchy_ of `m/44'/43'`. It is recommended for client implementations to follow this standard in order to achieve better cross-client compatibility.

For client implementations which _do not wish_ to implement the full capabilities of multi-account hierarchy for deterministic wallets, it is **recommended** to use only the following _default address path_: `m/44'/43'/0'/0'/0'`.

#### Examples

Following table displays example derivation paths with their corresponding hierarchy details. The two first path levels, namely the *purpose* and the *coin_type*, are always expected to contain `44'` and `43'` respectively. The next path levels, the third, represents the account number to be derived, and so on.

| account | keychain | address | path |
|---|---|---|---|
| **first** | **external** | **first** | `m/44'/43'/0'/0'/0'` |
| **first** | **external** | **second** | `m/44'/43'/0'/0'/1'` |
| **first** | **external** | **third** | `m/44'/43'/0'/0'/2'` |
| **first** | **internal** | **first** | `m/44'/43'/0'/1'/0'` |
| **first** | **internal** | **second** | `m/44'/43'/0'/1'/1'` |
| **first** | **internal** | **third** | `m/44'/43'/0'/1'/2'` |
| **second** | **external** | **first** | `m/44'/43'/1'/0'/0'` |
| **second** | **external** | **second** | `m/44'/43'/1'/0'/1'` |
| **second** | **external** | **third** | `m/44'/43'/1'/0'/2'` |
| **second** | **internal** | **first** | `m/44'/43'/1'/1'/0'` |
| **second** | **internal** | **second** | `m/44'/43'/1'/1'/1'` |
| **second** | **internal** | **third** | `m/44'/43'/1'/1'/2'` |

## Implementation

An implementation proposal has been started with following specification:

- Package name `nem2-hd-wallets@0.4.0` at https://github.com/evias/nem2-hd-wallets
- [`DeterministicKey`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Compat/DeterministicKey.ts) class to provide with `bitcoinjs/bip32` compatibility.
- [`NodeEd25519`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Curves/NodeEd25519.ts) class to describe hierarchical deterministic nodes for ED25519 elliptic curve cryptography.
- [`CKDPriv`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Curves/NodeEd25519.ts#L57) function implementation to permit **Private parent key --> Private child key** derivation.
- [`ExtendedKey`](https://github.com/evias/nem2-hd-wallets/blob/master/src/ExtendedKey.ts) class to add an abstraction layer for actual *keys*, higher level layer for working with extended keys.
- [`MnemonicPassPhrase`](https://github.com/evias/nem2-hd-wallets/blob/master/src/MnemonicPassPhrase.ts) class to describe BIP39 mnemonic pass phrases.
- [`Wallet`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Wallet.ts) class to describe hierarchical deterministic wallets compatible with `nem2-sdk` classes `Account` and `PublicAccount`.
- [`MACType`](https://github.com/evias/nem2-hd-wallets/blob/master/src/MACType.ts) enumeration with `HMAC` and `KMAC`.
- [`MACImpl`](https://github.com/evias/nem2-hd-wallets/blob/master/src/MACImpl.ts) class with `create` method to accept `MACType.KMAC` or `MACType.HMAC`and create message authentication code accordingly.
- [`HMAC`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Cryptography.ts#L60) method implementation in `Cryptography` class.
- [`KMAC`](https://github.com/evias/nem2-hd-wallets/blob/master/src/Cryptography.ts#L76) method implementation in `Cryptography` class.

The current implementation is open for suggestions. The library is now BIP32-compatible and allows generating *hardened-only* ED25519 extended keys.

### Ongoing Work

- [x] Replace HMAC for KMAC with https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf
- [x] Implement Wallet interface
- [ ] Implement Wallet creation out of extended private key hexadecimal format
- [ ] Implement KMAC specialized unit tests
- [ ] Add network type and network id in binary extended keys
- [x] Define relevance of `base58` encoding of extended keys for Catapult. [NOT RELEVANT]
- [ ] Integrate QR Code interface using `nem2-qr-code` when available.
- [ ] Make sure `privateKey`s can not be leaked through, for example, bad memory management in early draft phase.

## Integration

This package should aim at following integration examples:

```typescript
import {MnemonicPassPhrase, ExtendedKey, Wallet} from 'nem2-hd-wallets';

const mnemonic = MnemonicPassPhrase.createRandom();
const extended = ExtendedKey.fromSeed(mnemonic.toEntropy());
const wallet = new Wallet(extended);

// derive *master* account (not recommended)
const masterAccount = wallet.getAccount();

// derive *default* account (recommended)
const defaultAccount = wallet.getChildAccount(`m/44'/43'/0'/0'/0'`);
```

## References

- [BIP32: Hierarchical Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
- [BIP39: Mnemonic code for generating deterministic keys](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
- [BIP43: Purpose Field for Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki) 
- [BIP44: Multi-Account Hierarchy for Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
- [SLIP44 - Registered coin types](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
- [SLIP10 - Universal private key derivation](https://github.com/satoshilabs/slips/blob/master/slip-0010.md)
- [evias/nem2-hd-wallets](https://github.com/evias/nem2-hd-wallets)
- [Cardano Implementation Proposal in RUST](https://github.com/input-output-hk/rust-cardano/commit/5dd1416249128d7346028ef8cce713fd7bda0f28#diff-20f5bbac575dbd279d57a5959a3eb883)
- [SLIP-10 compliant ED25519-hd-keys](https://github.com/alepop/ed25519-hd-key/tree/master/src)
- [SLIP-10 compliant ED25519-hd-keys in RUST](https://github.com/tarassh/ed25519_hd_key/blob/master/src/lib.rs)
- [BIP32-Ed25519 Hierarchical Deterministic Keys over a Non-linear Keyspace](https://cardanolaunch.com/assets/Ed25519_BIP.pdf)
- [NIST.SP800-185](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf)

## History

| **Date**      | **Version**   |
| ------------- | ------------- |
| Apr 6 2019    | Initial Draft |
| Apr 18 2019   | Second Draft |
| Apr 23 2019   | Third Draft |
| Apr 29 2019   | Fourth Draft |
| May 13 2019   | Fifth Draft |
