### PR TITLE
Update NIP-0004 - Replace apostille metadata 

### DIFF
--- a/NIPs/nip-0004.md
+++ b/NIPs/nip-0004.md
@@ -23,8 +23,8 @@
     + [First inner transaction](#first-inner-transaction)
     + [Second inner transaction](#second-inner-transaction)
     + [Third inner transaction](#third-inner-transaction)
-    + [Fourth inner transaction](#fourth-inner-transaction)
-      - [Metadata JSON example](#metadata-json-example)
+    + [Fourth and later inner transaction](#fourth-and-later-inner-transaction)
+      - [Value for commonly used metadata keys](#value-for-commonly-used-metadata-keys)
     + [Sign and announce](#sign-and-announce)
   * [Tokenization of apostille asset](#tokenization-of-apostille-asset)
     + [Table of nonces](#table-of-nonces)
@@ -147,39 +147,36 @@ innerTransaction3 = multisigTx.toAggregate(<apostille public account>);
 
 cosignatory will be the PublicAccount of X<sub>0</sub> or any other public account to assign first ownership to.
 
-#### Fourth inner transaction
+#### Fourth and later inner transaction
 
-A fourth optional inner transaction can be added to contain certain apostille metadata.
+A fourth optional inner transaction can be added to contain certain apostille metadata to apostille account.
 
 ```typescript
-metadataTx = TransferTransaction.create(
+metadataTx = AccountMetadataTransaction.create(
     Deadline.create(),
-    <address of apostille account>
-    [],
-    PlainMessage.create(<metadata>),
+    <public Account of apostille account>
+    KeyGenerator.generateUInt64Key(<metadata key>),
+    <length of metadata value>,
+    <metadata>
     NetworkType.MIJIN_TEST
 );
 
-innerTransaction4 = metadataTx.toAggregate(<apostille public accout>);
+innerTransaction4orLater = metadataTx.toAggregate(<apostille public account>);
 ```
 
-where metadata is a JSON string.
+metadata key saved UInt64.
 
-##### Metadata JSON example
+##### Value for commonly used metadata keys
 
-```json
-{
-    "filename": "sample.pdf",
-    "tags": ["sample", "apostille"],
-    "description": "apostille sample file",
-    "originFileURL": "http://example.com/sample_file.pdf"
-}
-```
-
-> **Note**
->
-> - The size of the JSON payload is limited to the transaction message size.
-> - When Metadata Key/Value Association (#8) specification is decided and implemented, this section might use that feature. Future implementations should **always** check for a transfer transaction with a JSON payload to ensure backwards compatibility.
+| Value                | Key name                |
+| -------------------- | ----------------------- |
+| `0xB8A2B7186A421369` | Author                  |
+| `0xA801BEEB799108BC` | Title                   |
+| `0xEB9BDBED96B9EC45` | Tag                     |
+| `0x9E30087F94867CF9` | Description             |
+| `0xD298EBA89C34461D` | Filename                |
+| `0x9FA2FCC0B88961FC` | OriginUrl               |
+| `0x92F13A7B7DF2F7A9` | CertificateUrl          |
 
 #### Sign and announce
 


### PR DESCRIPTION
Catapult's metadata is implemented. So apostille metadata would be replaced from transfer transaction's message to account's metadata.