### PR TITLE
Updated NIP6: Updated BIP44 Coin Type for Symbol

### DIFF
--- a/NIPs/nip-0006.md
+++ b/NIPs/nip-0006.md
@@ -147,10 +147,10 @@ In our implementation proposal, we will be defining methods to derive master and
 
 In the **BIP32** and **BIP44** proposals, hardened keys are to be defined by having an **apostrophe** (') as the suffix of the path level index. Examples of _hardened paths_ include :
 
-- `m/44'/43'/0'/0'/0'`: first account, internal keychain, first address.
-- `m/44'/43'/0'/0'/1'`: first account, internal keychain, second address.
-- `m/44'/43'/1'/0'/5'`: second account, internal keychain, sixth address.
-- `m/44'/43'/1'/1'/5'`: second account, external keychain, sixth address.
+- `m/44'/4343'/0'/0'/0'`: first account, internal keychain, first address.
+- `m/44'/4343'/0'/0'/1'`: first account, internal keychain, second address.
+- `m/44'/4343'/1'/0'/5'`: second account, internal keychain, sixth address.
+- `m/44'/4343'/1'/1'/5'`: second account, external keychain, sixth address.
 
 :warning: **Following this definition, paths will _automatically_ be hardened in case they are non-hardened.**
 
@@ -276,7 +276,7 @@ m / purpose' / coin_type' / account' / change' / address_index'
 :warning: Note the addition of *hardened* change and address_index path levels. Because Catapult makes use of *ed25519* elliptic curve cryptography, deriving non-hardened extended keys is non-trivial and resources available on this topic are limited. For our implementation, we decided to use **hardened derivation only** because of the simplicity of implementation and the availability of tested resources and publications.
 
 - Our `purpose` level will be `44'` as we are building a logical hierarchy following the BIP44 standard. 
-- Our `coin_type` is `43'` as this corresponds to `NEM` in [SLIP-44 annexed to the source document](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).
+- Our `coin_type` is `4343''` as this corresponds to `Symbol` in [SLIP-44 annexed to the source document](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).
 - The next level corresponds to the _index_ of the `account` that we want to use, starting at `0` for the **first** account.
 - The `change` path level is used to _define which keychain must be used_. Set to `0'`, the keychain used is said to be `external`, while any other `change` path level will result in using the `internal` keychain.
 - The `address_index` path level corresponds to the _index_ of the `address` that we want to use, starting at `0'` for the **first** address.
@@ -285,28 +285,28 @@ The appended apostrophe (`'`) in path levels is used to mark **hardened key leve
 
 :warning: Our implementation proposal **only permits derivation of one of these keyspaces**, namely **the hardened key space**.
 
-For NEM, we can define a _base logical hierarchy_ of `m/44'/43'`. It is recommended for client implementations to follow this standard in order to achieve better cross-client compatibility.
+For NEM, we can define a _base logical hierarchy_ of `m/44'/4343'`. It is recommended for client implementations to follow this standard in order to achieve better cross-client compatibility.
 
-For client implementations which _do not wish_ to implement the full capabilities of multi-account hierarchy for deterministic wallets, it is **recommended** to use only the following _default address path_: `m/44'/43'/0'/0'/0'`.
+For client implementations which _do not wish_ to implement the full capabilities of multi-account hierarchy for deterministic wallets, it is **recommended** to use only the following _default address path_: `m/44'/4343'/0'/0'/0'`.
 
 #### Examples
 
-Following table displays example derivation paths with their corresponding hierarchy details. The two first path levels, namely the *purpose* and the *coin_type*, are always expected to contain `44'` and `43'` respectively. The next path levels, the third, represents the account number to be derived, and so on.
+Following table displays example derivation paths with their corresponding hierarchy details. The two first path levels, namely the *purpose* and the *coin_type*, are always expected to contain `44'` and `4343'` respectively. The next path levels, the third, represents the account number to be derived, and so on.
 
 | account | keychain | address | path |
 |---|---|---|---|
-| **first** | **external** | **first** | `m/44'/43'/0'/0'/0'` |
-| **first** | **external** | **second** | `m/44'/43'/0'/0'/1'` |
-| **first** | **external** | **third** | `m/44'/43'/0'/0'/2'` |
-| **first** | **internal** | **first** | `m/44'/43'/0'/1'/0'` |
-| **first** | **internal** | **second** | `m/44'/43'/0'/1'/1'` |
-| **first** | **internal** | **third** | `m/44'/43'/0'/1'/2'` |
-| **second** | **external** | **first** | `m/44'/43'/1'/0'/0'` |
-| **second** | **external** | **second** | `m/44'/43'/1'/0'/1'` |
-| **second** | **external** | **third** | `m/44'/43'/1'/0'/2'` |
-| **second** | **internal** | **first** | `m/44'/43'/1'/1'/0'` |
-| **second** | **internal** | **second** | `m/44'/43'/1'/1'/1'` |
-| **second** | **internal** | **third** | `m/44'/43'/1'/1'/2'` |
+| **first** | **external** | **first** | `m/44'/4343'/0'/0'/0'` |
+| **first** | **external** | **second** | `m/44'/4343'/0'/0'/1'` |
+| **first** | **external** | **third** | `m/44'/4343'/0'/0'/2'` |
+| **first** | **internal** | **first** | `m/44'/4343'/0'/1'/0'` |
+| **first** | **internal** | **second** | `m/44'/4343'/0'/1'/1'` |
+| **first** | **internal** | **third** | `m/44'/4343'/0'/1'/2'` |
+| **second** | **external** | **first** | `m/44'/4343'/1'/0'/0'` |
+| **second** | **external** | **second** | `m/44'/4343'/1'/0'/1'` |
+| **second** | **external** | **third** | `m/44'/4343'/1'/0'/2'` |
+| **second** | **internal** | **first** | `m/44'/4343'/1'/1'/0'` |
+| **second** | **internal** | **second** | `m/44'/4343'/1'/1'/1'` |
+| **second** | **internal** | **third** | `m/44'/4343'/1'/1'/2'` |
 
 ## Implementation
 
@@ -352,7 +352,7 @@ const wallet = new Wallet(extended);
 const masterAccount = wallet.getAccount();
 
 // derive *default* account (recommended)
-const defaultAccount = wallet.getChildAccount(`m/44'/43'/0'/0'/0'`);
+const defaultAccount = wallet.getChildAccount(`m/44'/4343'/0'/0'/0'`);
 ```
 
 ## References
@@ -362,6 +362,7 @@ const defaultAccount = wallet.getChildAccount(`m/44'/43'/0'/0'/0'`);
 - [BIP43: Purpose Field for Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki) 
 - [BIP44: Multi-Account Hierarchy for Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
 - [SLIP44 - Registered coin types](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
+- [SLIP44 - Pull request for Symbol](https://github.com/satoshilabs/slips/pull/887)
 - [SLIP10 - Universal private key derivation](https://github.com/satoshilabs/slips/blob/master/slip-0010.md)
 - [evias/nem2-hd-wallets](https://github.com/evias/nem2-hd-wallets)
 - [Cardano Implementation Proposal in RUST](https://github.com/input-output-hk/rust-cardano/commit/5dd1416249128d7346028ef8cce713fd7bda0f28#diff-20f5bbac575dbd279d57a5959a3eb883)
@@ -372,10 +373,11 @@ const defaultAccount = wallet.getChildAccount(`m/44'/43'/0'/0'/0'`);
 
 ## History
 
-| **Date**      | **Version**   |
-| ------------- | ------------- |
-| Apr 6 2019    | Initial Draft |
-| Apr 18 2019   | Second Draft |
-| Apr 23 2019   | Third Draft |
-| Apr 29 2019   | Fourth Draft |
-| May 13 2019   | Fifth Draft |
+| **Date**      | **Version**       |
+| ------------- | ----------------- |
+| Apr 6 2019    | Initial Draft     |
+| Apr 18 2019   | Second Draft      |
+| Apr 23 2019   | Third Draft       |
+| Apr 29 2019   | Fourth Draft      |
+| May 13 2019   | Fifth Draft       |
+| Apr 1 2020    | Updated Coin Type |


### PR DESCRIPTION
### Changed

- Coin type for Symbol changed from `43` to `4343`. 
- SLIP44 PR merged with coin type `4343` for Symbol (XYM): https://github.com/satoshilabs/slips/pull/887